### PR TITLE
Updated Build Instructions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Please refrain from contributing patches that conflict with the LICENSE or that 
 ### Pre-requisites
 
 - [Rust](https://www.rust-lang.org/) v1.7.0+ with `cargo`.
+- [Requirements to Build CZMQ](https://github.com/zeromq/czmq#building-and-installing) 
 
 ### Building from source
 

--- a/CREDITS
+++ b/CREDITS
@@ -16,3 +16,4 @@ Contributors:
 
 0. Kaustav Das Modak <kaustav.dasmodak@yahoo.co.in>
 1. Soumya Deb <debloper@gmail.com>
+2. Nootan Ghimire <nootan.ghimire@gmail.com>


### PR DESCRIPTION
The Build Instructions lacked information about things needed to build CZMQ.
Added That.